### PR TITLE
CI: update checkout action to latest available

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout repository and submodules
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4.2.2
       with:
         submodules: recursive
     - name: Build


### PR DESCRIPTION
The old one was triggering warnings due to the use of node12